### PR TITLE
hmrnn-2 : added class for HM LSTM output embeddings

### DIFF
--- a/HM_LSTM_Output_Embedder.py
+++ b/HM_LSTM_Output_Embedder.py
@@ -1,0 +1,49 @@
+import tensorflow as tf
+
+class HM_LSTM_Output_Embedder:
+
+  def __init__(self, num_layers, hidden_dim, output_emb_dim, activation=tf.nn.relu):
+
+      self._num_layers = num_layers
+      self._hidden_dim = hidden_dim
+      self._output_emb_dim = output_emb_dim
+      self._activation = activation
+
+  @property
+  def output_size(self):
+      return self._output_emb_dim
+
+  def apply(self, layer_outputs):
+      assert type(layer_outputs) == tuple
+      assert len(layer_outputs) == self._num_layers
+      assert layer_outputs[0].get_shape().as_list()[-1] == self._hidden_dim
+
+      # layer_outputs is a tuple of length num_layers of the layers' outputs.
+      # each layer output has shape [batch size, hidden_dim]
+
+      h_out = tf.concat([
+          tf.expand_dims(layer_outputs[idx], 1) for idx in range(0,len(layer_outputs))
+      ], 1)
+      # shape: [batch_size, num_layers, hidden_dim]
+
+      h_out_flat = tf.concat([
+          layer_outputs[idx] for idx in range(0,len(layer_outputs))
+      ], 1)
+      # shape: [batch_size, num_layers * hidden_dim]
+
+      layer_importance_gates = tf.layers.dense(h_out_flat, units=self._num_layers, use_bias=False, activation=tf.sigmoid)
+      layer_importance_gates = tf.expand_dims(layer_importance_gates, 2)
+
+      h_out_importance_gated = layer_importance_gates * h_out
+      # shape: [batch_size, num_layers, 1] * [batch_size, num_layers, hidden_dim] ->  # [batch_size, num_layers, hidden_dim]
+
+      h_out_importance_gated_flat = tf.reshape(
+          h_out_importance_gated, [-1, self._num_layers * self._hidden_dim])
+
+      h_out_emb = tf.layers.dense(h_out_importance_gated_flat, units=self._output_emb_dim, use_bias=False, activation=self._activation)
+      # shape: [batch_size, output_emb_dim]
+
+      return h_out_emb
+
+
+


### PR DESCRIPTION
The changes in this PR were primarily to maintain ease-of-use during the inference (deployment) stage, while staying true to the model proposed in the paper. 

Specifically, 

- The best way[™](https://tvtropes.org/pmwiki/pmwiki.php/Main/Tradesnark) to generate samples of a language model is to use a decoder from tf.contrib.seq2seq. 

- The [BasicDecoder](https://www.tensorflow.org/api_docs/python/tf/contrib/seq2seq/BasicDecoder) requires an RNNCell instance whose outputs will either: (a) serve as the logits directly, or (b) allow the decoder to obtain the logits through application of a single dense layer known as a [projection layer](https://stackoverflow.com/questions/39573188/output-projection-in-seq2seq-model-tensorflow). 

- The HMRNN Language Model proposed in the paper requires a number of additional computational steps after the layer outputs are obtained, and before the logits can be computed via a projection layer. 

- These computational steps require access to all layers' outputs jointly at a given timestep, and thus must be applied at the level of the multicell, rather than within the individual cells. 

- This made the use of a seq2seq decoder difficult; I could not pass the output embeddings to the BasicDecoder, because it takes an RNNCell. Nor could I omit the output embeddings, because the BasicDecoder uses a [Helper](https://www.tensorflow.org/api_docs/python/tf/contrib/seq2seq/Helper) that requires access to the logits. 

This PR solves these challenges by introducing a new class, HM_LSTM_Output_Embedder, that can be passed to a Multi_HM_LSTM_Cell during instantiation. 

HM_LSTM_Output_Embedder enables Multi_HM_LSTM_Cell to run all the additional computational steps from the paper, each time the 'call' method for the latter is invoked. 

Among other things, this allows us to use a BasicDecoder.